### PR TITLE
refactor: take out current working directory from the file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-src/**/__tests__
+dist/**/__tests__

--- a/__tests__/productionCodeCheck.test.ts
+++ b/__tests__/productionCodeCheck.test.ts
@@ -3,8 +3,8 @@ import { readFileSync } from "fs";
 import { cwd } from "process";
 
 describe("Make sure there is no production code in this repository", () => {
-  test("Shoud not have js or ts files under `src` folder", () => {
-    const directoryPath = `${cwd()}/src`;
+  test("Shoud not have js or ts files under `dist` folder", () => {
+    const directoryPath = `${cwd()}/dist`;
     const hasProductionCode = productionCodeCheck(directoryPath);
     expect(hasProductionCode).toStrictEqual([]);
   });
@@ -23,7 +23,7 @@ describe("Make sure there is no production code in this repository", () => {
   });
 
   test("Make sure src/environment.ts not expose any type", () => {
-    const environmentPath = `${cwd()}/src/environment.d.ts`;
+    const environmentPath = `${cwd()}/dist/types/environment.d.ts`;
     // Make sure only export empty object if the environment file exist
     try {
       const fileContent = readFileSync(environmentPath, "utf-8");

--- a/__tests__/productionCodeCheck.test.ts
+++ b/__tests__/productionCodeCheck.test.ts
@@ -13,10 +13,10 @@ describe("Make sure there is no production code in this repository", () => {
     const hasProductionCode = productionCodeCheck(mockFolderPath);
     expect(hasProductionCode).toMatchInlineSnapshot(`
       [
-        "/Users/thienhuynh/zonos/zonos-elements-readme/__tests__/__mocks__/productionCodeCheck/mockTypescriptFile.ts",
-        "/Users/thienhuynh/zonos/zonos-elements-readme/__tests__/__mocks__/productionCodeCheck/mockTsxFile.tsx",
-        "/Users/thienhuynh/zonos/zonos-elements-readme/__tests__/__mocks__/productionCodeCheck/mockJsxFile.jsx",
-        "/Users/thienhuynh/zonos/zonos-elements-readme/__tests__/__mocks__/productionCodeCheck/mockJsFile.js",
+        "./__tests__/__mocks__/productionCodeCheck/mockTypescriptFile.ts",
+        "./__tests__/__mocks__/productionCodeCheck/mockTsxFile.tsx",
+        "./__tests__/__mocks__/productionCodeCheck/mockJsxFile.jsx",
+        "./__tests__/__mocks__/productionCodeCheck/mockJsFile.js",
       ]
     `);
   });

--- a/__tests__/productionCodeCheck.test.ts
+++ b/__tests__/productionCodeCheck.test.ts
@@ -1,4 +1,5 @@
 import { productionCodeCheck } from "__tests__/productionCodeCheck";
+import { readFileSync } from "fs";
 import { cwd } from "process";
 
 describe("Make sure there is no production code in this repository", () => {
@@ -19,5 +20,16 @@ describe("Make sure there is no production code in this repository", () => {
         "./__tests__/__mocks__/productionCodeCheck/mockJsFile.js",
       ]
     `);
+  });
+
+  test("Make sure src/environment.ts not expose any type", () => {
+    const environmentPath = `${cwd()}/src/environment.d.ts`;
+    // Make sure only export empty object if the environment file exist
+    try {
+      const fileContent = readFileSync(environmentPath, "utf-8");
+      expect(fileContent).toMatchInlineSnapshot(`"export type Env = {};"`);
+    } catch (_err) {
+      // Do nothing
+    }
   });
 });

--- a/__tests__/productionCodeCheck.ts
+++ b/__tests__/productionCodeCheck.ts
@@ -20,9 +20,10 @@ export const productionCodeCheck = (path: string) => {
 
   const fullPathWithExt = `${path}/**/*.{ts*,js*}`;
   const globPaths = globSync(fullPathWithExt);
-  const hasNonDeclarationFiles = globPaths.filter(
-    (filePath) => !filePath.endsWith(".d.ts"),
-  );
+  const hasNonDeclarationFiles = globPaths
+    .filter((filePath) => !filePath.endsWith(".d.ts"))
+    // Take out the current working directory from the file path
+    .map((filePath) => filePath.replace(`${cwd()}/`, "./"));
 
   // Determine if there are files that are not declaration files, indicating the presence of production code
   return hasNonDeclarationFiles;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "@sentry/browser": "^7.111.0",
+    "@stencil/core": "^4.18.3",
     "@stencil/store": "^2.0.15",
     "@stripe/stripe-js": "^3.3.0",
     "@types/eslint": "^8.56.10",
@@ -28,7 +29,8 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.13.0",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "zod": "^3.23.8"
   },
   "keywords": [],
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ devDependencies:
   '@sentry/browser':
     specifier: ^7.111.0
     version: 7.117.0
+  '@stencil/core':
+    specifier: ^4.18.3
+    version: 4.18.3
   '@stencil/store':
     specifier: ^2.0.15
     version: 2.0.16(@stencil/core@4.18.3)
@@ -65,6 +68,9 @@ devDependencies:
   vitest:
     specifier: ^1.6.0
     version: 1.6.0(@types/node@20.14.2)
+  zod:
+    specifier: ^3.23.8
+    version: 3.23.8
 
 packages:
 
@@ -2240,4 +2246,8 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  /zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
+    "skipLibCheck": true,
     "noImplicitAny": false,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,
-    "skipLibCheck": true,
     "noImplicitAny": false,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
@@ -20,9 +19,9 @@
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
-      "src/*": ["./src/*"],
+      "src/*": ["./dist/types/*"],
     },
   },
-  "include": ["src/**/*", "__tests__/**/*"],
+  "include": ["dist/types/**/*", "__tests__/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description
This PR updates the test not to include the current working directory, also change the root directory to be `dist` instead of `src` so it can be consistent and easy to reference from the README from private zonos elements project.